### PR TITLE
Update MS5837.cpp

### DIFF
--- a/MS5837.cpp
+++ b/MS5837.cpp
@@ -208,7 +208,7 @@ uint8_t MS5837::crc4(uint16_t n_prom[]) {
 
 	for ( uint8_t i = 0 ; i < 16; i++ ) {
 		if ( i%2 == 1 ) {
-			n_rem ^= (uint16_t)((n_prom[i>>1]) & 0x00FF0);
+			n_rem ^= (uint16_t)((n_prom[i>>1]) & 0x00FF);
 		} else {
 			n_rem ^= (uint16_t)(n_prom[i>>1] >> 8);
 		}


### PR DESCRIPTION
Line 211 had 0x00FF0, changed to 0x00FF to make CRC4 go to sucsess instead of failure (refering to datasheet, requires 0x00FF not 0x00FF0)