### PR TITLE
Allow for higher resolution return from pressure sensor

### DIFF
--- a/MS5837.cpp
+++ b/MS5837.cpp
@@ -150,17 +150,22 @@ void MS5837::calculate() {
 	OFF2 = OFF-OFFi;           //Calculate pressure and temp second order
 	SENS2 = SENS-SENSi;
 	
+	TEMP = (TEMP-Ti);
+	
 	if ( _model == MS5837_02BA ) {
-		TEMP = (TEMP-Ti);
-		P = (((D1*SENS2)/2097152l-OFF2)/32768l)/100;
+		P = (((D1*SENS2)/2097152l-OFF2)/32768l); 
 	} else {
-		TEMP = (TEMP-Ti);
-		P = (((D1*SENS2)/2097152l-OFF2)/8192l)/10;
+		P = (((D1*SENS2)/2097152l-OFF2)/8192l);
 	}
 }
 
 float MS5837::pressure(float conversion) {
-	return P*conversion;
+    if ( _model == MS5837_02BA ) {
+        return P*conversion/100.0f;
+    }
+    else {
+        return P*conversion/10.0f;
+    }
 }
 
 float MS5837::temperature() {


### PR DESCRIPTION
Hi All!

Thanks so much for your awesome work on this sensor -- I'm finding it super useful.

I believe that the reason that the library was returning only integer values of the pressure value involved integer vs. floating point division.

I've made some small changes to the calculation of both P and the pressure, so that the returned value has a higher resolution.

I'm new to doing pull requests, figured I'd give it a shot :)

Cheerio!
D
