### PR TITLE
Fix compiler errors when compiling for Arduino Nano 33 BLE platform

### DIFF
--- a/MS5837.cpp
+++ b/MS5837.cpp
@@ -60,13 +60,13 @@ void MS5837::setFluidDensity(float density) {
 void MS5837::read() {
 	// Request D1 conversion
 	Wire.beginTransmission(MS5837_ADDR);
-	Wire.write(MS5837_CONVERT_D1_8192);
+	Wire.write((int)MS5837_CONVERT_D1_8192);
 	Wire.endTransmission();
 
 	delay(20); // Max conversion time per datasheet
 	
 	Wire.beginTransmission(MS5837_ADDR);
-	Wire.write(MS5837_ADC_READ);
+	Wire.write((int)MS5837_ADC_READ);
 	Wire.endTransmission();
 
  	Wire.requestFrom(MS5837_ADDR,3);
@@ -83,7 +83,7 @@ void MS5837::read() {
 	delay(20); // Max conversion time per datasheet
 	
 	Wire.beginTransmission(MS5837_ADDR);
-	Wire.write(MS5837_ADC_READ);
+	Wire.write((int)MS5837_ADC_READ);
 	Wire.endTransmission();
 
 	Wire.requestFrom(MS5837_ADDR,3);

--- a/MS5837.cpp
+++ b/MS5837.cpp
@@ -70,10 +70,10 @@ void MS5837::read() {
 	Wire.endTransmission();
 
  	Wire.requestFrom(MS5837_ADDR,3);
-	D1 = 0;
-	D1 = Wire.read();
-	D1 = (D1 << 8) | Wire.read();
-	D1 = (D1 << 8) | Wire.read();
+	D1_pres = 0;
+	D1_pres = Wire.read();
+	D1_pres = (D1_pres << 8) | Wire.read();
+	D1_pres = (D1_pres << 8) | Wire.read();
 	
 	// Request D2 conversion
 	Wire.beginTransmission(MS5837_ADDR);
@@ -87,10 +87,10 @@ void MS5837::read() {
 	Wire.endTransmission();
 
 	Wire.requestFrom(MS5837_ADDR,3);
-	D2 = 0;
-	D2 = Wire.read();
-	D2 = (D2 << 8) | Wire.read();
-	D2 = (D2 << 8) | Wire.read();
+	D2_temp = 0;
+	D2_temp = Wire.read();
+	D2_temp = (D2_temp << 8) | Wire.read();
+	D2_temp = (D2_temp << 8) | Wire.read();
 
 	calculate();
 }
@@ -109,15 +109,15 @@ void MS5837::calculate() {
 	int64_t SENS2 = 0;
 	
 	// Terms called
-	dT = D2-uint32_t(C[5])*256l;
+	dT = D2_temp-uint32_t(C[5])*256l;
 	if ( _model == MS5837_02BA ) {
 		SENS = int64_t(C[1])*65536l+(int64_t(C[3])*dT)/128l;
 		OFF = int64_t(C[2])*131072l+(int64_t(C[4])*dT)/64l;
-		P = (D1*SENS/(2097152l)-OFF)/(32768l);
+		P = (D1_pres*SENS/(2097152l)-OFF)/(32768l);
 	} else {
 		SENS = int64_t(C[1])*32768l+(int64_t(C[3])*dT)/256l;
 		OFF = int64_t(C[2])*65536l+(int64_t(C[4])*dT)/128l;
-		P = (D1*SENS/(2097152l)-OFF)/(8192l);
+		P = (D1_pres*SENS/(2097152l)-OFF)/(8192l);
 	}
 	
 	// Temp conversion
@@ -153,9 +153,9 @@ void MS5837::calculate() {
 	TEMP = (TEMP-Ti);
 	
 	if ( _model == MS5837_02BA ) {
-		P = (((D1*SENS2)/2097152l-OFF2)/32768l); 
+		P = (((D1_pres*SENS2)/2097152l-OFF2)/32768l); 
 	} else {
-		P = (((D1*SENS2)/2097152l-OFF2)/8192l);
+		P = (((D1_pres*SENS2)/2097152l-OFF2)/8192l);
 	}
 }
 

--- a/MS5837.h
+++ b/MS5837.h
@@ -85,7 +85,7 @@ public:
 
 private:
 	uint16_t C[8];
-	uint32_t D1, D2;
+	uint32_t D1_pres, D2_temp;
 	int32_t TEMP;
 	int32_t P;
 	uint8_t _model;


### PR DESCRIPTION
My fix for #20. 

I renamed a couple of variables `D1` and `D2` as they were causing a conflict with certain Arduino headers for the Nano 33 BLE. I also added a cast-to-integer in some of the calls to `Wire::write`, as the new mbed-based implementation of `Wire.h` provides two candidates, `write(uint8_t)` and `write(char*)`. 

I tried my best to make sure this code doesn't break anything else. I tried compiling for a few different Arduino platforms, including: Arduino Uno, Arduino Nano, Arduino Nano 33 BLE, Arduino Nano Every, Arduino Portenta H7, and Arduino Nano 33 IOT, and the library compiled without any issues. I apologise for not knowing the proper procedure to test my code thoroughly, I am a student and very new to this. 